### PR TITLE
Support travis pro

### DIFF
--- a/lib/coveralls/lcov/converter.rb
+++ b/lib/coveralls/lcov/converter.rb
@@ -14,7 +14,7 @@ module Coveralls
           source_files << generate_source_file(filename, info)
         end
         payload = {
-          service_name: "travis-ci",
+          service_name: @service_name,
           service_job_id: ENV["TRAVIS_JOB_ID"],
           git: git_info,
           source_files: source_files,

--- a/lib/coveralls/lcov/converter.rb
+++ b/lib/coveralls/lcov/converter.rb
@@ -2,9 +2,10 @@
 module Coveralls
   module Lcov
     class Converter
-      def initialize(tracefile, source_encoding = Encoding::UTF_8)
+      def initialize(tracefile, source_encoding = Encoding::UTF_8, service_name = "travis-ci")
         @tracefile = tracefile
         @source_encoding = source_encoding
+        @service_name = service_name
       end
 
       def convert

--- a/lib/coveralls/lcov/runner.rb
+++ b/lib/coveralls/lcov/runner.rb
@@ -17,6 +17,7 @@ module Coveralls
         @n_times = 3
         @delay = 3
         @source_encoding = Encoding::UTF_8
+        @service_name = "travis-ci"
         @verbose = false
         @dry_run = false
         @parser = OptionParser.new(@argv)
@@ -28,6 +29,9 @@ module Coveralls
 BANNER
         @parser.on("-t", "--repo-token=TOKEN", "Repository token") do |token|
           @repo_token = token
+        end
+        @parser.on("-s", "--service-name=SERVICENAME", "Service name") do |service_name|
+          @service_name = service_name
         end
         @parser.on("--retry=N", Integer, "Retry to POST N times (default: 3)") do |n_times|
           @n_times = n_times

--- a/lib/coveralls/lcov/runner.rb
+++ b/lib/coveralls/lcov/runner.rb
@@ -59,7 +59,7 @@ BANNER
           exit false
         end
         tracefile = @argv.shift
-        converter = Converter.new(tracefile, @source_encoding)
+        converter = Converter.new(tracefile, @source_encoding, @service_name)
         payload = converter.convert
         payload[:repo_token] = @repo_token if @repo_token
         payload_json = payload.to_json

--- a/lib/coveralls/lcov/version.rb
+++ b/lib/coveralls/lcov/version.rb
@@ -1,5 +1,5 @@
 module Coveralls
   module Lcov
-    VERSION = "1.1.3"
+    VERSION = "1.1.4"
   end
 end


### PR DESCRIPTION
This changes allows travis-pro users to use this tool to upload data to coveralls.

Travis-pro users have to specify the 'service-name' keyword for coveralls to link to the correct commits.