### PR TITLE
fix linecount when record occurs multiple times

### DIFF
--- a/lib/coveralls/lcov/version.rb
+++ b/lib/coveralls/lcov/version.rb
@@ -1,5 +1,5 @@
 module Coveralls
   module Lcov
-    VERSION = "1.5.0"
+    VERSION = "1.5.1"
   end
 end


### PR DESCRIPTION
I tried to get lcov-coveralls working with earcut.hpp, but lcov gave me an _info_ file which contains the same file-record multiple times for different compilation units.
genhtml works fine with it, but when running lcov-coveralls with that file, it incorrectly computes zero coverage.

example info file (line coverage only): https://gist.github.com/mrgreywater/aef66982363298ae2efa9ae161cae4d7

The same might be necessary for branches. (info file with branches and functions: https://gist.github.com/mrgreywater/1622824601464a740c0b5df2b75faaca)