### PR TITLE
Add support for parallel builds

### DIFF
--- a/lib/coveralls/lcov/runner.rb
+++ b/lib/coveralls/lcov/runner.rb
@@ -24,6 +24,7 @@ module Coveralls
         @host = "coveralls.io"
         @port = 443
         @use_ssl = true
+        @parallel = ENV["COVERALLS_PARALLEL"] == "true"
         @parser = OptionParser.new(@argv)
         @parser.banner = <<BANNER
   Usage: coveralls-lcov [options] coverage.info
@@ -83,6 +84,7 @@ BANNER
         elsif coveralls_config && coveralls_config["repo_token"]
           payload[:repo_token] = coveralls_config["repo_token"]
         end
+        payload[:parallel] = @parallel
         payload_json = payload.to_json
         puts payload_json if @verbose
         unless @dry_run


### PR DESCRIPTION
From https://docs.coveralls.io/parallel-build-webhook and
https://docs.coveralls.io/api-reference, all that is needed is to
pass-through an environment variable to a field named 'parallel' in
the job payload.

Note I don't actually know Ruby, so feel free to suggest or implement 
a more idiomatic way.

Signed-off-by: Iustin Pop <iustin@k1024.org>