### PR TITLE
lcov: converter: support TRAVIS_BRANCH env variable

### DIFF
--- a/lib/coveralls/lcov/converter.rb
+++ b/lib/coveralls/lcov/converter.rb
@@ -97,7 +97,7 @@ module Coveralls
             message: `git log -1 --format=%s`,
           },
           remotes: [], # FIXME need this?
-          branch: `git rev-parse --abbrev-ref HEAD`,
+          branch: ENV["TRAVIS_BRANCH"] || `git rev-parse --abbrev-ref HEAD`,
         }
       end
 


### PR DESCRIPTION
This commit allow coveralls-lcov to take current branch into account when building, which might not be available otherwise depending on the git configuration of the build.

I'm not really sure of the syntax and wasn't sure of how to test though, as I don't really use it.